### PR TITLE
Use new skalibs pathexec function names

### DIFF
--- a/src/justc-envdir/justc-envdir.c
+++ b/src/justc-envdir/justc-envdir.c
@@ -9,7 +9,7 @@
 #include <skalibs/env.h>
 #include <skalibs/direntry.h>
 #include <skalibs/stralloc.h>
-#include <skalibs/djbunix.h>
+#include <skalibs/stddjb.h>
 
 #define USAGE "justc-envdir [-I | -i ] dir prog..."
 
@@ -36,7 +36,7 @@ int main (int argc, char const *const *argv, char const *const *envp)
   if (argc < 2) strerr_dieusage(100, USAGE) ;
   if ((justc_envdir(*argv++, &modifs) < 0) && (insist || (errno != ENOENT)))
     strerr_diefu1sys(111, "justc_envdir") ;
-  xpathexec_r(argv, envp, env_len(envp), modifs.s, modifs.len) ;
+  xmexec_fm(argv, envp, env_len(envp), modifs.s, modifs.len) ;
 }
 
 static int justc_envdir (char const *path, stralloc *modifs)


### PR DESCRIPTION
Skalibs have provided a new function naming scheme in commit [18e4356](https://github.com/skarnet/skalibs/commit/18e43565574b700befc832ed4d25d25e40951f68), which deprecated `xpathexec_r`, and then [removed](https://github.com/skarnet/skalibs/commit/38da4384d3b4630787430b9b38bd4726e00cc7d9) it from compatibility layer. This patch provides the necessary replacement.